### PR TITLE
Default network name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,21 +7,15 @@ services:
     environment:
       POSTGRES_DB: 'manifold_production'
       POSTGRES_HOST_AUTH_METHOD: 'trust'
-    networks:
-      - network1
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.7
     environment:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
       xpack.security.enabled: 'false'
-    networks:
-      - network1
   redis:
     image: redis:alpine
     volumes:
       - ./data/redis:/data
-    networks:
-      - network1
   api_cable:
     image: manifoldscholarship/manifold-api:${MANIFOLD_TAG}
     volumes:
@@ -29,8 +23,6 @@ services:
       - ./data/sockets:/manifold_sockets
     env_file:
       - ./environment/manifold.env
-    networks:
-      - network1
     command: ["./start-and-run", "bin/cable"]
   api_clockwork:
     image: manifoldscholarship/manifold-api:${MANIFOLD_TAG}
@@ -40,8 +32,6 @@ services:
     env_file:
       - ./environment/manifold.env
       - ./environment/rails.env
-    networks:
-      - network1
     command: ["./start-and-run", "bin/zhong zhong.rb"]
   api_rails:
     image: manifoldscholarship/manifold-api:${MANIFOLD_TAG}
@@ -51,8 +41,6 @@ services:
     env_file:
       - ./environment/manifold.env
     command: ["./start-and-run", "bin/puma -C config/puma.rb"]
-    networks:
-      - network1
   api_sidekiq:
     image: manifoldscholarship/manifold-api:${MANIFOLD_TAG}
     volumes:
@@ -60,8 +48,6 @@ services:
       - ./data/sockets:/manifold_sockets
     env_file:
       - ./environment/manifold.env
-    networks:
-      - network1
     command: ["./start-and-run", "bin/sidekiq"]
   client:
     image: manifoldscholarship/manifold-client:${MANIFOLD_TAG}
@@ -71,8 +57,6 @@ services:
       - ./data/api/public:/opt/manifold/api/public
       - ./data/sockets:/manifold_sockets
     command: yarn run start-docker
-    networks:
-      - network1
   proxy:
     image: manifoldscholarship/manifold-nginx:${MANIFOLD_TAG}
     volumes:
@@ -83,11 +67,6 @@ services:
      - "4000:80"
      - "4001:443"
     command: ["start-nginx"]
-    networks:
-      - network1
 #volumes:
 #  manifold_data:
 #  manifold_sockets:
-
-networks:
-  network1:


### PR DESCRIPTION
All services are in same network. docker-compose has a naming convention for it:  directoryname plus '_default'.  That feature is available since 2015.

Removing the 'network1' name definitions brings 'manifold_default' in the output of `docker network ls`. Much better as 'network1', aspecial on host running multiple docker-compose instances.